### PR TITLE
Implicit conversion from float to int loses precision

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /nbproject/private/
 composer.lock
 phpunit.xml
+.*

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "traderinteractive/util": "^3.0||^4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=6.5",
+        "phpunit/phpunit": ">=6.5 <11.0",
         "squizlabs/php_codesniffer": "^3.2"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,4 +1,8 @@
 <phpunit colors="true" forceCoversAnnotation="true">
+    <php>
+        <ini name="error_reporting" value="E_ALL"/>
+        <ini name="display_errors" value="On"/>
+    </php>
     <testsuites>
         <testsuite name="TraderInteractive Library Test Suite">
             <directory suffix="Test.php">tests</directory>

--- a/src/Image.php
+++ b/src/Image.php
@@ -386,7 +386,7 @@ final class Image
 
             //put image in box
             $canvas = self::getBackgroundCanvas($source, $color, $blurBackground, $blurValue, $boxWidth, $boxHeight);
-            if ($canvas->compositeImage($clone, \Imagick::COMPOSITE_ATOP, $targetX, $targetY) !== true) {
+            if ($canvas->compositeImage($clone, \Imagick::COMPOSITE_ATOP, (int)$targetX, (int)$targetY) !== true) {
                 //cumbersome to test
                 throw new \Exception('Imagick::compositeImage() did not return true');//@codeCoverageIgnore
             }


### PR DESCRIPTION
#### What does this PR do?
This pull request fixes the issue when a height or width is calculated to a float, but the implicit conversion error is thrown instead of casting to an integer
#### Checklist
- [ ] Pull request contains a clear definition of changes
- [ ] Tests (either unit, integration, or acceptance) written and passing
- [ ] Relevant documentation produced and/or updated
